### PR TITLE
Update DockerHub org to golioth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
           file: ./images/xk6-coap/Dockerfile
           platforms: linux/amd64
           load: true
-          tags: goliothiot/xk6-coap
+          tags: golioth/xk6-coap
 
       - name: Login to Dockerhub
         uses: docker/login-action@v1
         if: github.ref == 'refs/heads/main'
         with:
-          username: goliothiot
+          username: goliothbot
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and Push to Dockerhub
@@ -45,4 +45,4 @@ jobs:
           file: ./images/xk6-coap/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: goliothiot/xk6-coap
+          tags: golioth/xk6-coap

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@
 ## Getting Started
 
 To get started, either build the `k6` binary or use the
-[`goliothiot/xk6-coap`](https://hub.docker.com/repository/docker/goliothiot/xk6-coap)
+[`golioth/xk6-coap`](https://hub.docker.com/repository/docker/golioth/xk6-coap)
 image.
 
 ### Using the OCI Image
 
-The quickest way to get started is by using the `goliothiot/xk6-coap` image,
+The quickest way to get started is by using the `golioth/xk6-coap` image,
 which is [built](./images/xk6-coap/Dockerfile) from this repository and
 published to DockerHub. Tests can be supplied when creating a container from the
 image via a [bind mount](https://docs.docker.com/storage/bind-mounts/). For
@@ -25,7 +25,7 @@ example, the following command would run the [simple
 example](./examples/simple.js) from this repository.
 
 ```
-docker run -it --rm -e COAP_PSK_ID=<YOUR-PSK-ID> -e COAP_PSK=<YOUR-PSK> -v $(pwd)/examples/simple.js:/simple.js goliothiot/xk6-coap k6 run /simple.js --vus 10 --duration 5s
+docker run -it --rm -e COAP_PSK_ID=<YOUR-PSK-ID> -e COAP_PSK=<YOUR-PSK> -v $(pwd)/examples/simple.js:/simple.js golioth/xk6-coap k6 run /simple.js --vus 10 --duration 5s
 ```
 
 `xk6-coap` supports authentication via pre-shared keys (PSKs) and client


### PR DESCRIPTION
Moves from goliothiot to the official golioth DockerHub org.

Fixes #18 